### PR TITLE
Use `woocommerce_payment_complete_order_status` filter

### DIFF
--- a/wcs-auto-complete-order.php
+++ b/wcs-auto-complete-order.php
@@ -1,42 +1,47 @@
 <?php
 /**
-* Plugin Name: WooCommerce Subscriptions - Auto-Complete Orders
-* Plugin URI: https://github.com/Prospress/woocommerce-subscriptions-auto-complete-orders
-* Description: Auto-completes all orders after successful payment - even subscription renewals.
-* Author: Prospress Inc.
-* Author URI: http://prospress.com/
-* Version: 1.0
-* License: GPLv3
-*
-* GitHub Plugin URI: Prospress/woocommerce-subscriptions-auto-complete-orders
-* GitHub Branch: master
-*
-* Copyright 2018 Prospress, Inc.  (email : freedoms@prospress.com)
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*
-* @package		WooCommerce Subscriptions
-* @author		Prospress Inc.
-* @since		1.0
-*/
+ * Plugin Name: WooCommerce Subscriptions - Auto-Complete Orders
+ * Plugin URI:  https://github.com/Prospress/woocommerce-subscriptions-auto-complete-orders
+ * Description: Auto-completes all orders after successful payment - even subscription renewals.
+ * Author:      Prospress Inc.
+ * Author URI:  http://prospress.com/
+ * Version:     1.1.0
+ * License:     GPLv3
+ *
+ * GitHub Plugin URI: Prospress/woocommerce-subscriptions-auto-complete-orders
+ * GitHub Branch: master
+ *
+ * Copyright 2018 Prospress, Inc.  (email : freedoms@prospress.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @package WooCommerce Subscriptions
+ * @author  Prospress Inc.
+ * @since   1.0.0
+ */
 
-add_action( 'woocommerce_payment_complete', 'woocommerce_subscriptions_auto_complete_order' );
-function woocommerce_subscriptions_auto_complete_order( $order_id ) { 
-    if ( ! $order_id ) {
-        return;
-    }
-
-    $order = wc_get_order( $order_id );
-    $order->update_status( 'completed' );
+add_filter( 'woocommerce_payment_complete_order_status', 'wcs_aco_return_completed' );
+/**
+ * Return "completed" as an order status.
+ *
+ * This should be attached to the woocommerce_payment_complete_order_status hook.
+ *
+ * @since 1.1.0
+ *
+ * @param string $status The current default status.
+ * @return string The filtered default status.
+ */
+function wcs_aco_return_completed( $status ) {
+	return 'completed';
 }


### PR DESCRIPTION
@jrick1229 This is a nifty plugin. I found that this can be done a bit more simply by tying into the `woocommerce_payment_complete_order_status` filter, rather than triggering an action. This prevents the need to call `wc_get_order()` and then manually update the status to `completed`. Instead, `completed` will be used as the default status for orders.